### PR TITLE
Fix dpi

### DIFF
--- a/src/wglmakie.js
+++ b/src/wglmakie.js
@@ -632,7 +632,7 @@ const WGLMakie = (function () {
         renderer.setClearColor("#ffffff");
         renderer.setPixelRatio(window.devicePixelRatio);
         
-        renderer.setSize(window.innerWidth, window.innerHeight + 20);
+        renderer.setSize(window.innerWidth, 1.1*window.innerHeight);
         
         function mousemove(event) {
             var rect = canvas.getBoundingClientRect();

--- a/src/wglmakie.js
+++ b/src/wglmakie.js
@@ -630,10 +630,11 @@ const WGLMakie = (function () {
         });
 
         renderer.setClearColor("#ffffff");
-        renderer.setPixelRatio(window.devicePixelRatio);
-        
-        renderer.setSize(window.innerWidth, window.innerHeight);
-        
+
+        var pixelRatio = window.devicePixelRatio
+        renderer.setPixelRatio(pixelRatio);
+        renderer.setSize(canvas.width / pixelRatio, canvas.height / pixelRatio);
+
         function mousemove(event) {
             var rect = canvas.getBoundingClientRect();
             var x = event.clientX - rect.left;

--- a/src/wglmakie.js
+++ b/src/wglmakie.js
@@ -631,7 +631,7 @@ const WGLMakie = (function () {
 
         renderer.setClearColor("#ffffff");
 
-        var pixelRatio = window.devicePixelRatio
+        var pixelRatio = window.devicePixelRatio;
         renderer.setPixelRatio(pixelRatio);
         renderer.setSize(canvas.width / pixelRatio, canvas.height / pixelRatio);
 

--- a/src/wglmakie.js
+++ b/src/wglmakie.js
@@ -93,7 +93,7 @@ const WGLMakie = (function () {
             cam3d.near,
             cam3d.far
         );
-	
+
         const center = new THREE.Vector3(...cam3d.lookat);
         camera.up = new THREE.Vector3(...cam3d.upvector);
         camera.position.set(...cam3d.eyeposition);
@@ -632,7 +632,7 @@ const WGLMakie = (function () {
         renderer.setClearColor("#ffffff");
         renderer.setPixelRatio(window.devicePixelRatio);
         
-        renderer.setSize(window.innerWidth, 1.1*window.innerHeight);
+        renderer.setSize(window.innerWidth, window.innerHeight);
         
         function mousemove(event) {
             var rect = canvas.getBoundingClientRect();

--- a/src/wglmakie.js
+++ b/src/wglmakie.js
@@ -93,7 +93,7 @@ const WGLMakie = (function () {
             cam3d.near,
             cam3d.far
         );
-
+	
         const center = new THREE.Vector3(...cam3d.lookat);
         camera.up = new THREE.Vector3(...cam3d.upvector);
         camera.position.set(...cam3d.eyeposition);
@@ -630,8 +630,10 @@ const WGLMakie = (function () {
         });
 
         renderer.setClearColor("#ffffff");
-        renderer.setPixelRatio(1);
-
+        renderer.setPixelRatio(window.devicePixelRatio);
+        
+        renderer.setSize(window.innerWidth, window.innerHeight + 20);
+        
         function mousemove(event) {
             var rect = canvas.getBoundingClientRect();
             var x = event.clientX - rect.left;


### PR DESCRIPTION
Continues on #98. It takes the pixel ratio from the device and then adjusts the size accordingly.

This should probably be squashed when merging because commit history is very noisy.

New look:

<img width="659" alt="highreswgl" src="https://user-images.githubusercontent.com/6333339/119652400-58a25380-be26-11eb-8ecf-172a11e0c26f.png">

Docs seem OK and look sharper than on master: http://juliaplots.org/WGLMakie.jl/previews/PR107/