### PR TITLE
simplify and document canvas size handling

### DIFF
--- a/src/three_plot.jl
+++ b/src/three_plot.jl
@@ -63,7 +63,7 @@ function three_display(session::Session, scene::Scene)
 
     width, height = size(scene)
 
-    canvas = DOM.um("canvas", width=width, height=height, tabindex="0")
+    canvas = DOM.um("canvas", tabindex="0")
     wrapper = DOM.div(canvas)
     comm = Observable(Dict{String,Any}())
     push!(session, comm)

--- a/src/three_plot.jl
+++ b/src/three_plot.jl
@@ -84,9 +84,8 @@ function three_display(session::Session, scene::Scene)
             const cam = new $(THREE).PerspectiveCamera(45, 1, 0, 100)
             $(WGL).start_renderloop(renderer, three_scenes, cam)
             JSServe.on_update($canvas_width, w_h => {
+                // `renderer.setSize` correctly updates `canvas` dimensions
                 renderer.setSize(w_h[0], w_h[1]);
-                canvas.style.width = w_h[0];
-                canvas.style.height = w_h[1];
             })
         } else {
             const warning = $(WEBGL).getWebGLErrorMessage();

--- a/src/wglmakie.js
+++ b/src/wglmakie.js
@@ -630,10 +630,12 @@ const WGLMakie = (function () {
         });
 
         renderer.setClearColor("#ffffff");
-
-        var pixelRatio = window.devicePixelRatio;
-        renderer.setPixelRatio(pixelRatio);
-        renderer.setSize(canvas.width / pixelRatio, canvas.height / pixelRatio);
+        // The following handles high-DPI devices
+        // After calling `renderer.setPixelRatio`,
+        // `canvas.width = window.devicePixelRatio * width` and
+        // `canvas.height = window.devicePixelRatio * height`
+        renderer.setPixelRatio(window.devicePixelRatio);
+        renderer.setSize(width, height);
 
         function mousemove(event) {
             var rect = canvas.getBoundingClientRect();


### PR DESCRIPTION
Small follow-up on #107. My understanding is the following:

- `renderer.setPixelRatio` sets the pixel ratio between CSS pixels and device pixels
- `renderer.setSize` sets the size in device pixels (which is what we want, as that is how the user passes the information)

`renderer.setPixelRatio` and `renderer.setSize` also update the `canvas` dimensions to match what is specified. In particular, this means that we do not need to mess with the `canvas` style after the fact. We also do not need to set the `canvas.width` beforehand, especially because that value is inaccurate (it ignores the `devicePixelRatio`).