### PR TITLE
make sure devicePixelRatio is checked exactly once

### DIFF
--- a/src/three_plot.jl
+++ b/src/three_plot.jl
@@ -85,7 +85,7 @@ function three_display(session::Session, scene::Scene)
             $(WGL).start_renderloop(renderer, three_scenes, cam)
             JSServe.on_update($canvas_width, w_h => {
                 // `renderer.setSize` correctly updates `canvas` dimensions
-                var pixelRatio = window.devicePixelRatio;
+                const pixelRatio = renderer.getPixelRatio();
                 renderer.setSize(w_h[0] / pixelRatio, w_h[1] / pixelRatio);
             })
         } else {

--- a/src/wglmakie.js
+++ b/src/wglmakie.js
@@ -579,7 +579,7 @@ const WGLMakie = (function () {
         renderer.autoClear = scene.clearscene;
         const area = JSServe.get_observable(scene.pixelarea);
         if (area) {
-            const [x, y, w, h] = area.map(t => t / window.devicePixelRatio);
+            const [x, y, w, h] = area.map(t => t / pixelRatio);
             renderer.setViewport(x, y, w, h);
             renderer.setScissor(x, y, w, h);
             renderer.setScissorTest(true);


### PR DESCRIPTION
Hopefully this is the last tweak needed for the resolution. I think it's important that we check `window.devicePixelRatio` exactly once (and store that info in the renderer), otherwise things get really weird when resizing. For instance, zooming on [this page](http://juliaplots.org/WGLMakie.jl/dev/) breaks. With this PR, `pixelRatio` is set to the initial `window.devicePixelRatio` and left unchanged, so that the plot resizes normally with the page.

~I am still not sure giving resolution in device pixels is the best idea though, I'll open a separate issue to discuss that.~ Never mind, I'm still not sure I understand all the implications of the various systems...